### PR TITLE
Add the RPS in the template

### DIFF
--- a/loadsweb/templates/run.tmpl
+++ b/loadsweb/templates/run.tmpl
@@ -40,7 +40,6 @@
 
   <dt>Duration</dt>
   <dd>{{info['metadata']['duration']}}</dd>
-
 </dl>
 
 
@@ -69,6 +68,10 @@
 
  <dt>Bytes/websockets</dt>
  <dd id="count-socket_message">{{info['counts'].get('socket_message', 0)}}</dd>
+
+ <dt>Requests / second (RPS)</dt>
+ <dd id="count-rps">{{ info['counts'].get('rps') }}</dd>
+
 
 
 %if len(info['custom']) > 0:


### PR DESCRIPTION
I'm not sure this is as straightforward as this. The goal is to display the RPS for the current run.

It seems this information was already provided by the APIs, just not displayed by the template. This fixes it.
IIUC, the code in `loads.js` will directly update this since it starts with `count-`.
